### PR TITLE
Add environment variable expansion for INI config values

### DIFF
--- a/core/shell_util.cpp
+++ b/core/shell_util.cpp
@@ -266,3 +266,32 @@ std::string GetHomeDir() {
 }
 
 }  // namespace slop
+
+#include <cstdlib>
+#include <regex>
+
+namespace slop {
+
+std::string ExpandEnvVars(const std::string& input) {
+  std::string result = input;
+  // Match ${VAR}
+  static const std::regex braced_regex(R"(\$\{([^}]+)\})");
+  std::smatch match;
+  while (std::regex_search(result, match, braced_regex)) {
+    const char* env_val = std::getenv(match[1].str().c_str());
+    std::string replacement = env_val ? env_val : "";
+    result.replace(match.position(), match.length(), replacement);
+  }
+  
+  // Match $VAR (alphanumeric and underscores)
+  static const std::regex simple_regex(R"(\$([a-zA-Z_][a-zA-Z0-9_]*))");
+  while (std::regex_search(result, match, simple_regex)) {
+    const char* env_val = std::getenv(match[1].str().c_str());
+    std::string replacement = env_val ? env_val : "";
+    result.replace(match.position(), match.length(), replacement);
+  }
+  
+  return result;
+}
+
+}  // namespace slop

--- a/core/shell_util.h
+++ b/core/shell_util.h
@@ -45,6 +45,9 @@ bool IsEscPressed();
 // Returns the current user's home directory.
 std::string GetHomeDir();
 
+// Expands environment variables in the format ${VAR_NAME} or $VAR_NAME.
+std::string ExpandEnvVars(const std::string& input);
+
 }  // namespace slop
 
 #endif  // SLOP_SHELL_UTIL_H_

--- a/docs/example_config.ini
+++ b/docs/example_config.ini
@@ -1,25 +1,14 @@
+# To use this config, run: std_slop --config docs/example_config.ini
+# Environment variables will be resolved at runtime.
+
 [slop]
-# Path to the SQLite database
+# OpenRouter via OpenAI-compatible API
+openai_api_key = ${LOGGING_OPENROUTER_API_KEY}
+openai_base_url = https://openrouter.ai/api/v1
+
+# Default model (cheap + explicitly agentic in model description)
+model = google/gemini-3-flash-preview
+
+# Optional
+strip_reasoning = true
 # db = ~/.config/slop/slop.db
-
-# LLM Model to use (e.g., gemini-2.0-flash-exp, gpt-4o)
-# model = gemini-2.0-flash-exp
-
-# Google API Key
-# google_api_key = AIza...
-
-# OpenAI API Key
-# If set, slop will default to the OpenAI provider.
-# openai_api_key = sk-...
-
-# OpenAI Base URL (for OAI-compatible proxies)
-# openai_base_url = https://api.openai.com/v1
-
-# Enable Google OAuth (defaults to true if no API keys are found)
-# google_oauth = true
-
-# Google Cloud Project ID for OAuth mode
-# project = my-project-id
-
-# Strip reasoning/thought blocks from model output
-# strip_reasoning = true

--- a/ini/BUILD.bazel
+++ b/ini/BUILD.bazel
@@ -6,6 +6,7 @@ cc_library(
     hdrs = ["ini_parser.h"],
     visibility = ["//visibility:public"],
     deps = [
+        "//core:shell_lib",
         "@abseil-cpp//absl/strings",
     ],
 )

--- a/ini/ini_parser.cpp
+++ b/ini/ini_parser.cpp
@@ -1,3 +1,4 @@
+#include "core/shell_util.h"
 #include "ini/ini_parser.h"
 
 #include "absl/strings/ascii.h"
@@ -31,7 +32,7 @@ IniConfig ParseIni(std::string_view content) {
         value_view = value_view.substr(0, comment_pos);
       }
 
-      std::string value = std::string(absl::StripAsciiWhitespace(value_view));
+      std::string value = ExpandEnvVars(std::string(absl::StripAsciiWhitespace(value_view)));
       if (!key.empty()) {
         config[current_section][key] = value;
       }

--- a/ini/ini_parser_test.cpp
+++ b/ini/ini_parser_test.cpp
@@ -48,4 +48,22 @@ TEST(IniParserTest, EmptyAndGlobal) {
 }
 
 }  // namespace
+TEST(IniParserTest, EnvironmentVariableExpansion) {
+  setenv("TEST_VAR", "expanded_value", 1);
+  std::string ini = "key = ${TEST_VAR}\nkey2 = $TEST_VAR";
+  auto config = ParseIni(ini);
+  EXPECT_EQ(config[""]["key"], "expanded_value");
+  EXPECT_EQ(config[""]["key2"], "expanded_value");
+  unsetenv("TEST_VAR");
+}
+
+TEST(IniParserTest, MissingEnvironmentVariable) {
+  // Ensure the variable is NOT set
+  unsetenv("NON_EXISTENT_VAR");
+  std::string ini = "key = ${NON_EXISTENT_VAR}";
+  auto config = ParseIni(ini);
+  // Current implementation expands missing vars to empty strings
+  EXPECT_EQ(config[""]["key"], "");
+}
+
 }  // namespace slop


### PR DESCRIPTION
Hi, I saw your mail model mention on hn, commented. Decided to try the tool. I like this way of  working. Used this pr as a way to learn it. I think in my world I would use a permanent mail model with ai-generated code, always need to revisit base assumptions. I like that it forces testsuites to keep working.

Note while the mail  model was cool, std_slop is clearly very early :)

## Summary
- add ExpandEnvVars utility to expand `$VAR/${VAR}` placeholders
- apply env var expansion to INI values read from config
- add tests for env var expansion behavior and sample config examples

## Test Plan
- [x] bazel test //...
